### PR TITLE
Add additional networking statistics

### DIFF
--- a/LiteNetLib/NetManager.Socket.cs
+++ b/LiteNetLib/NetManager.Socket.cs
@@ -608,7 +608,7 @@ namespace LiteNetLib
 
             if (EnableStatistics)
             {
-                Statistics.IncrementPacketsSent();
+                Statistics.IncrementPacketsSent(1);
                 Statistics.AddBytesSent(length);
             }
 

--- a/LiteNetLib/NetPeer.cs
+++ b/LiteNetLib/NetPeer.cs
@@ -1268,7 +1268,7 @@ namespace LiteNetLib
 
             if (NetManager.EnableStatistics)
             {
-                Statistics.IncrementPacketsSent();
+                Statistics.IncrementPacketsSent(_mergeCount);
                 Statistics.AddBytesSent(bytesSent);
             }
 
@@ -1288,7 +1288,7 @@ namespace LiteNetLib
 
                 if (NetManager.EnableStatistics)
                 {
-                    Statistics.IncrementPacketsSent();
+                    Statistics.IncrementPacketsSent(1);
                     Statistics.AddBytesSent(bytesSent);
                 }
 

--- a/LiteNetLib/NetStatistics.cs
+++ b/LiteNetLib/NetStatistics.cs
@@ -18,6 +18,7 @@ namespace LiteNetLib
         private long _bytesSent;
         private long _bytesReceived;
         private long _packetLoss;
+        private long _windowWaits;
 
         ConcurrentQueue<long> _packetSizes = new ConcurrentQueue<long>();
         ConcurrentQueue<int> _packetMerges = new ConcurrentQueue<int>();
@@ -27,6 +28,7 @@ namespace LiteNetLib
         public long BytesSent => Interlocked.Read(ref _bytesSent);
         public long BytesReceived => Interlocked.Read(ref _bytesReceived);
         public long PacketLoss => Interlocked.Read(ref _packetLoss);
+        public long WindowWaitCount => Interlocked.Read(ref _windowWaits);
 
         public long PacketLossPercent
         {
@@ -86,6 +88,7 @@ namespace LiteNetLib
             Interlocked.Exchange(ref _bytesSent, 0);
             Interlocked.Exchange(ref _bytesReceived, 0);
             Interlocked.Exchange(ref _packetLoss, 0);
+            Interlocked.Exchange(ref _windowWaits, 0);
 
 #if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
             _packetSizes.Clear();
@@ -129,17 +132,23 @@ namespace LiteNetLib
             Interlocked.Add(ref _packetLoss, packetLoss);
         }
 
+        public void IncrementWindowWaits()
+        {
+            Interlocked.Increment(ref _windowWaits);
+        }
+
         public override string ToString()
         {
             return
                 string.Format(
-                    "BytesReceived: {0}\nPacketsReceived: {1}\nBytesSent: {2}\nPacketsSent: {3}\nPacketLoss: {4}\nPacketLossPercent: {5}\n",
+                    "BytesReceived: {0}\nPacketsReceived: {1}\nBytesSent: {2}\nPacketsSent: {3}\nPacketLoss: {4}\nPacketLossPercent: {5}\nWindow Wait Count: {6}",
                     BytesReceived,
                     PacketsReceived,
                     BytesSent,
                     PacketsSent,
                     PacketLoss,
-                    PacketLossPercent);
+                    PacketLossPercent,
+                    WindowWaitCount);
         }
     }
 }

--- a/LiteNetLib/ReliableChannel.cs
+++ b/LiteNetLib/ReliableChannel.cs
@@ -187,7 +187,12 @@ namespace LiteNetLib
                     {
                         int relate = NetUtils.RelativeSequenceNumber(_localSeqence, _localWindowStart);
                         if (relate >= _windowSize)
+                        {
+                            if (Peer.NetManager.EnableStatistics)
+                                Peer.Statistics.IncrementWindowWaits();
+
                             break;
+                        }
 
                         var netPacket = OutgoingQueue.Dequeue();
                         netPacket.Sequence = (ushort) _localSeqence;

--- a/LiteNetLib/ReliableChannel.cs
+++ b/LiteNetLib/ReliableChannel.cs
@@ -294,7 +294,7 @@ namespace LiteNetLib
             //detailed check
             if (seq == _remoteSequence)
             {
-                NetDebug.Write("[RR]ReliableInOrder packet succes");
+                NetDebug.Write("[RR]ReliableInOrder packet success");
                 Peer.AddReliablePacket(_deliveryMethod, packet);
                 _remoteSequence = (_remoteSequence + 1) % NetConstants.MaxSequence;
 


### PR DESCRIPTION
This adds new statistics to track following:
- Average sent packet size
- Average packet merge count
- Number of times the outgoing queue had to wait for the window to have a free slot

This should help diagnose a number of issues with LNL.